### PR TITLE
C++11 / build selection fixes

### DIFF
--- a/src/data.cpp
+++ b/src/data.cpp
@@ -101,7 +101,7 @@ void ProgramData::loadBuilds() {
       File file = data_->ngdp_->load(cdn_hash);
       if (!file) return -1;
       data_->cdn_config = NGDP::ParseConfig(file);
-      data_->builds = split(data_->cdn_config["builds"]);
+	  data_->builds.push_back(data_->ngdp_->version()->build);
       notify(0);
       for (size_t i = 0; i < data_->builds.size() && !terminate_; ++i) {
         std::string build = data_->builds[i];

--- a/src/frameui/fontsys.h
+++ b/src/frameui/fontsys.h
@@ -27,7 +27,17 @@ class FontSys {
     {
       fs.font = nullptr;
     }
-    FontStruct(FontStruct const& fs) = delete;
+	FontStruct &operator=(FontStruct &&fs) {
+		if (&fs != this) {
+			font = fs.font;
+			face = std::move(fs.face);
+			size = fs.size;
+			flags = fs.flags;
+			fs.font = nullptr;
+		}
+		return *this;
+	}
+	FontStruct(FontStruct const& fs) = delete;
     ~FontStruct() {
       if (font) DeleteObject(font);
     }

--- a/src/frameui/window.cpp
+++ b/src/frameui/window.cpp
@@ -63,7 +63,7 @@ WNDCLASSEX* Window::createclass(std::string const& wndClass) {
     wcx->lpfnWndProc = WindowProc;
     wcx->hInstance = hInstance;
     wcx->lpszClassName = regClass.c_str();
-    wcx->hCursor = LoadCursor(NULL, MAKEINTRESOURCE(IDC_ARROW));
+    wcx->hCursor = LoadCursor(NULL, IDC_ARROW);
     return wcx;
   }
   delete wcx;
@@ -79,7 +79,7 @@ void Window::create(int x, int y, int width, int height, std::string const& text
     wcex.lpfnWndProc = WindowProc;
     wcex.hInstance = GetModuleHandle(NULL);
     wcex.lpszClassName = "WUTILSWINDOW";
-    wcex.hCursor = LoadCursor(NULL, MAKEINTRESOURCE(IDC_ARROW));
+    wcex.hCursor = LoadCursor(NULL, IDC_ARROW);
     windowClass = RegisterClassEx(&wcex);
   }
   hWnd = CreateWindowEx(exStyle, regClass.empty() ? "WUTILSWINDOW" : regClass.c_str(), text.c_str(), style,

--- a/src/ngdp.cpp
+++ b/src/ngdp.cpp
@@ -58,8 +58,8 @@ namespace NGDP {
       auto& config = versions_[parts[0]];
       config.build = parts[1];
       config.cdn = parts[2];
-      config.id = std::stoi(parts[3]);
-      config.version = parts[4];
+      config.id = std::stoi(parts[4]);
+      config.version = parts[5];
       if (cdns_.count(parts[0])) {
         regions_.push_back(parts[0]);
       }

--- a/vc13/BlizzGet.vcxproj
+++ b/vc13/BlizzGet.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -19,13 +19,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -53,12 +53,13 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../libs;../src;./</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>../libs</AdditionalLibraryDirectories>
-      <AdditionalDependencies>comctl32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">


### PR DESCRIPTION
1. Fix FontStruct to be C++11 compliant (doesn't compile on new gcc or VS2015)
2. Update vcxproj/linking for VS2015
3. Fix crashing on region selection (an extra column was added in /versions)
4. Just use the current build instead of the now non-existent build list
5. Fix warnings in window.cpp due to incorrectly nested use of MAKEINTRESOURCE